### PR TITLE
feat(m1): start-of-game countdown and paddle lock during resets

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -268,7 +268,7 @@ export default class GameScene extends Phaser.Scene {
     }
 
     // Reset puck and start short countdown; pause timer
-    const dirY = scoredBy === 'player' ? 1 : -1; // opponent conceded -> serve up; player conceded -> serve down
+    const dirY = scoredBy === 'player' ? -1 : 1; // opponent conceded -> serve up; player conceded -> serve down
     this.startCountdownAndServe(dirY);
   }
 


### PR DESCRIPTION
Purpose: Implements a 3..2..1 countdown at game start and ensures paddles are 
locked during all countdowns (start and post-goal), addressing the bug where pad
dles could move during the reset timer.

  Changes
  - GameScene.create: Starts the match with a 3..2..1 countdown and randomized i
nitial serve direction.
  - GameScene.handleGoal: Uses the same countdown helper for post-goal resets.
  - GameScene.startCountdownAndServe: New helper that centers/stops the puck, em
its HUD countdown ticks, and serves after countdown.
  - GameScene.update: Early-return when inReset is true so player and AI paddles
 stay locked during countdown.

  Notes
  - HUD already displays the countdown via reset:countdown events; no HUD change
s.
  - TypeScript build compiles; full Vite build wasn’t run here due to sandbox.

  Testing
  - npm run dev
  - On load: HUD shows 3..2..1; paddles don’t move; puck serves after countdown.
  - Score a goal: same 3..2..1 appears; paddles remain locked; puck serves towar
d the conceding side.
  - Confirm the main timer does not tick down during countdowns.
  - Confirm normal play resumes after serve.

  Screenshots/GIFs
  - Optional: attach a short clip showing start-of-game countdown and paddle loc
k.

  Checklist
  - [x] TS compiles locally
  - [x] Branch: bugfix/lock-paddle
  - [x] Conventional commit message